### PR TITLE
feat: enforce weekly Yoasobi scheduling and authorize deletion

### DIFF
--- a/apps/client/codegen.ts
+++ b/apps/client/codegen.ts
@@ -13,6 +13,12 @@ const config: CodegenConfig = {
         withHooks: true,
         withHOC: false,
         withComponent: false,
+        scalars: {
+          DateTime: {
+            input: 'string',
+            output: 'string',
+          },
+        },
       },
     },
   },

--- a/apps/client/components/alert.component.tsx
+++ b/apps/client/components/alert.component.tsx
@@ -6,13 +6,22 @@ type IAlertProps = {
   isOpen: boolean;
   onClose: () => void;
   alertPadding?: GetThemeValueForKey<'padding'> | number;
+  contentBorderRadius?: number;
   bg?: GetThemeValueForKey<'backgroundColor'> | OpaqueColorValue;
   isErrorAlert?: boolean;
   children: ReactNode;
 };
 
 export const Alert = memo<IAlertProps>(
-  ({ isOpen, onClose, alertPadding = '$size.x2', bg = '$colors.midnightPurple', isErrorAlert = false, children }) => {
+  ({
+    isOpen,
+    onClose,
+    alertPadding = '$size.x2',
+    contentBorderRadius = 0,
+    bg = '$colors.midnightPurple',
+    isErrorAlert = false,
+    children,
+  }) => {
     const handlePressCloseAlert = useCallback(() => {
       onClose();
     }, [onClose]);
@@ -31,9 +40,9 @@ export const Alert = memo<IAlertProps>(
             bg={bg}
             borderWidth={1}
             borderColor={isErrorAlert ? '$colors.emberRed' : '$colors.cloudGray'}
-            radiused={false}
             p={alertPadding}
             y={0}
+            style={{ borderRadius: contentBorderRadius }}
             enterStyle={{
               scale: 0.96,
               y: 20,

--- a/apps/client/constants/yoasobi.constant.ts
+++ b/apps/client/constants/yoasobi.constant.ts
@@ -1,2 +1,3 @@
 export const MIN_YOASOBI_DURATION_MINUTES = 10;
 export const MAX_YOASOBI_DURATION_MINUTES = 180;
+export const MS_PER_DAY = 1000 * 60 * 60 * 24;

--- a/apps/client/libs/graphql/generated.tsx
+++ b/apps/client/libs/graphql/generated.tsx
@@ -16,7 +16,7 @@ export type Scalars = {
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
-  DateTime: { input: any; output: any; }
+  DateTime: { input: string; output: string; }
 };
 
 export type CreateUserInputDto = {
@@ -151,21 +151,21 @@ export type CreateUserMutationVariables = Exact<{
 }>;
 
 
-export type CreateUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'CreateUserOutputDto', user: { __typename?: 'UserEntity', id: string, name: string, timezone: string, createdAt: any, updatedAt: any } } };
+export type CreateUserMutation = { __typename?: 'Mutation', createUser: { __typename?: 'CreateUserOutputDto', user: { __typename?: 'UserEntity', id: string, name: string, timezone: string, createdAt: string, updatedAt: string } } };
 
 export type GetExistingUserQueryVariables = Exact<{
   input: GetUserInputDto;
 }>;
 
 
-export type GetExistingUserQuery = { __typename?: 'Query', getUser: { __typename?: 'GetUserOutputDto', user?: { __typename?: 'UserEntity', id: string, name: string, timezone: string, createdAt: any, updatedAt: any } | null } };
+export type GetExistingUserQuery = { __typename?: 'Query', getUser: { __typename?: 'GetUserOutputDto', user?: { __typename?: 'UserEntity', id: string, name: string, timezone: string, createdAt: string, updatedAt: string } | null } };
 
 export type GetWeeklyYoasobiQueryVariables = Exact<{
   input: GetYoasobiInputDto;
 }>;
 
 
-export type GetWeeklyYoasobiQuery = { __typename?: 'Query', getYoasobi: { __typename?: 'GetYoasobiOutputDto', yoasobi?: { __typename?: 'YoasobiEntity', id: string, yoasobiDate: any, dayOfWeek: DayOfWeek, alarmTime: any, duration: number, createdAt: any } | null } };
+export type GetWeeklyYoasobiQuery = { __typename?: 'Query', getYoasobi: { __typename?: 'GetYoasobiOutputDto', yoasobi?: { __typename?: 'YoasobiEntity', id: string, yoasobiDate: string, dayOfWeek: DayOfWeek, alarmTime: string, duration: number, createdAt: string } | null } };
 
 export type CreateYoasobiMutationVariables = Exact<{
   input: CreateYoasobiInputDto;

--- a/apps/client/libs/graphql/generated.tsx
+++ b/apps/client/libs/graphql/generated.tsx
@@ -62,6 +62,15 @@ export type DeleteUserOutputDto = {
   success: Scalars['Boolean']['output'];
 };
 
+export type DeleteYoasobiInputDto = {
+  yoasobiId: Scalars['String']['input'];
+};
+
+export type DeleteYoasobiOutputDto = {
+  __typename?: 'DeleteYoasobiOutputDto';
+  success: Scalars['Boolean']['output'];
+};
+
 export type GetUserInputDto = {
   userId: Scalars['String']['input'];
 };
@@ -91,6 +100,7 @@ export type Mutation = {
   createUser: CreateUserOutputDto;
   createYoasobi: CreateYoasobiOutputDto;
   deleteUser: DeleteUserOutputDto;
+  deleteYoasobi: DeleteYoasobiOutputDto;
 };
 
 
@@ -106,6 +116,11 @@ export type MutationCreateYoasobiArgs = {
 
 export type MutationDeleteUserArgs = {
   input: DeleteUserInputDto;
+};
+
+
+export type MutationDeleteYoasobiArgs = {
+  input: DeleteYoasobiInputDto;
 };
 
 export type Query = {
@@ -160,6 +175,8 @@ export type GetExistingUserQueryVariables = Exact<{
 
 export type GetExistingUserQuery = { __typename?: 'Query', getUser: { __typename?: 'GetUserOutputDto', user?: { __typename?: 'UserEntity', id: string, name: string, timezone: string, createdAt: string, updatedAt: string } | null } };
 
+export type YoasobiFieldsFragment = { __typename?: 'YoasobiEntity', id: string, yoasobiDate: string, dayOfWeek: DayOfWeek, alarmTime: string, duration: number, createdAt: string };
+
 export type GetWeeklyYoasobiQueryVariables = Exact<{
   input: GetYoasobiInputDto;
 }>;
@@ -172,9 +189,18 @@ export type CreateYoasobiMutationVariables = Exact<{
 }>;
 
 
-export type CreateYoasobiMutation = { __typename?: 'Mutation', createYoasobi: { __typename?: 'CreateYoasobiOutputDto', yoasobi: { __typename?: 'YoasobiEntity', id: string } } };
+export type CreateYoasobiMutation = { __typename?: 'Mutation', createYoasobi: { __typename?: 'CreateYoasobiOutputDto', yoasobi: { __typename?: 'YoasobiEntity', id: string, yoasobiDate: string, dayOfWeek: DayOfWeek, alarmTime: string, duration: number, createdAt: string } } };
 
-
+export const YoasobiFieldsFragmentDoc = gql`
+    fragment YoasobiFields on YoasobiEntity {
+  id
+  yoasobiDate
+  dayOfWeek
+  alarmTime
+  duration
+  createdAt
+}
+    `;
 export const CreateUserDocument = gql`
     mutation CreateUser($input: CreateUserInputDto!) {
   createUser(input: $input) {
@@ -267,16 +293,11 @@ export const GetWeeklyYoasobiDocument = gql`
     query getWeeklyYoasobi($input: GetYoasobiInputDto!) {
   getYoasobi(input: $input) {
     yoasobi {
-      id
-      yoasobiDate
-      dayOfWeek
-      alarmTime
-      duration
-      createdAt
+      ...YoasobiFields
     }
   }
 }
-    `;
+    ${YoasobiFieldsFragmentDoc}`;
 
 /**
  * __useGetWeeklyYoasobiQuery__
@@ -317,11 +338,11 @@ export const CreateYoasobiDocument = gql`
     mutation createYoasobi($input: CreateYoasobiInputDto!) {
   createYoasobi(input: $input) {
     yoasobi {
-      id
+      ...YoasobiFields
     }
   }
 }
-    `;
+    ${YoasobiFieldsFragmentDoc}`;
 export type CreateYoasobiMutationFn = Apollo.MutationFunction<CreateYoasobiMutation, CreateYoasobiMutationVariables>;
 
 /**

--- a/apps/client/screens/auth/auth.screen.tsx
+++ b/apps/client/screens/auth/auth.screen.tsx
@@ -568,25 +568,35 @@ export const AuthScreen = memo<IAuthScreenProps>(({ authType }) => {
   return (
     <LinearGradientLayout screenEdge={['top']} hasHeader>
       {!!authError && (
-        <Alert isOpen={!!authError} alertPadding="$size.x4" isErrorAlert onClose={handleCloseAuthError}>
-          <Stack width="$fluid" gap="$size.x4">
-            <Stack width="$fluid" gap="$size.x3">
-              <Stack flexDirection="row" items="center" gap="$size.x2_5">
-                <Stack py="$size.x1_5" px="$size.x1" bg="#ff909057" style={{ borderRadius: 12 }}>
-                  <FontAwesomeIcon icon={faExclamation} size={24} color="#ff7474" />
-                </Stack>
-                <Text fontSize="$9" fontWeight="$900">
-                  {authError.authType === 'login' ? '로그인' : '회원가입'}에 실패했어요
-                </Text>
+        <Alert
+          isOpen={!!authError}
+          alertPadding="$size.x4"
+          contentBorderRadius={12}
+          isErrorAlert
+          onClose={handleCloseAuthError}>
+          <Stack width="$fluid" gap="$size.x4" items="center">
+            <Stack width="$fluid" gap="$size.x2_5" items="center">
+              <Stack
+                width="$size.x13"
+                height="$size.x13"
+                justify="center"
+                items="center"
+                bg="#ff484883"
+                style={{ borderRadius: 50 }}>
+                <FontAwesomeIcon icon={faExclamation} size={26} color="#E67E7E" />
               </Stack>
-              <Text fontSize="$5" color="$colors.cloudGray">
+              <Text fontSize="$8" fontWeight="$900" color="$colors.moonSoftWhite" style={{ textAlign: 'center' }}>
+                {authError.authType === 'login' ? '로그인' : '회원가입'}에 실패했어요
+              </Text>
+              <Text fontSize="$5" fontWeight="$600" color="$colors.cloudGray" style={{ textAlign: 'center' }}>
                 {authError.message}
               </Text>
             </Stack>
+            <Separator width="$fluid" borderColor="#ffffff1f" />
             <Button
               width="$fluid"
               height="$fit"
-              py="$size.x2_5"
+              py="$size.x3"
               bg="$colors.lampYellow"
               borderTopLeftRadius="$size.x3"
               borderTopRightRadius="$size.x3"

--- a/apps/client/screens/home/home.screen.graphql
+++ b/apps/client/screens/home/home.screen.graphql
@@ -1,12 +1,16 @@
+fragment YoasobiFields on YoasobiEntity {
+  id
+  yoasobiDate
+  dayOfWeek
+  alarmTime
+  duration
+  createdAt
+}
+
 query getWeeklyYoasobi($input: GetYoasobiInputDto!) {
   getYoasobi(input: $input) {
     yoasobi {
-      id
-      yoasobiDate
-      dayOfWeek
-      alarmTime
-      duration
-      createdAt
+      ...YoasobiFields
     }
   }
 }
@@ -14,7 +18,7 @@ query getWeeklyYoasobi($input: GetYoasobiInputDto!) {
 mutation createYoasobi($input: CreateYoasobiInputDto!) {
   createYoasobi(input: $input) {
     yoasobi {
-      id
+      ...YoasobiFields
     }
   }
 }

--- a/apps/client/screens/home/home.screen.tsx
+++ b/apps/client/screens/home/home.screen.tsx
@@ -4,6 +4,7 @@ import {
   DAY_OF_WEEK_TEXT,
   MAX_YOASOBI_DURATION_MINUTES,
   MIN_YOASOBI_DURATION_MINUTES,
+  MS_PER_DAY,
 } from '@/constants';
 import { DayOfWeek, useCreateYoasobiMutation, useGetWeeklyYoasobiLazyQuery } from '@/libs';
 import { getDateByDayOfWeekUtil, getWeekStartDateUtil } from '@/utils';
@@ -16,6 +17,7 @@ import { faStopwatch } from '@fortawesome/free-solid-svg-icons/faStopwatch';
 import { faBurst } from '@fortawesome/free-solid-svg-icons/faBurst';
 import { faMoon } from '@fortawesome/free-solid-svg-icons/faMoon';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { useFocusEffect } from 'expo-router';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import RNDateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { Button, ColorTokens, Progress, ScrollView, Separator, Sheet, Stack, Switch, Text } from 'tamagui';
@@ -33,6 +35,7 @@ type IYoasobi = {
 
 type IYoasobiChoiceBoxProps = {
   selectedDayOfWeek: DayOfWeek;
+  selectableDaysOfWeek: DayOfWeek[];
   isMidnightNotificationEnabled: boolean;
   isShowStartTime: boolean;
   isShowDuration: boolean;
@@ -56,9 +59,31 @@ type IYoasobiResultBoxProps = {
   createdDate: Date;
 };
 
+const isSameLocalDate = (firstDate: Date, secondDate: Date) =>
+  firstDate.getFullYear() === secondDate.getFullYear() &&
+  firstDate.getMonth() === secondDate.getMonth() &&
+  firstDate.getDate() === secondDate.getDate();
+
+const getSelectableDaysOfWeek = (currentDate: Date) => DAY_OF_WEEK_ARRAY.slice(currentDate.getDay() + 1);
+
+const getYoasobiDateForDay = ({
+  weekStartDate,
+  dayOfWeek,
+  previousDate,
+}: {
+  weekStartDate: Date;
+  dayOfWeek: DayOfWeek;
+  previousDate: Date;
+}) => {
+  const { dateByDayOfWeek } = getDateByDayOfWeekUtil({ weekStartDate, dayOfWeek });
+  dateByDayOfWeek.setHours(previousDate.getHours(), previousDate.getMinutes(), 0, 0);
+  return dateByDayOfWeek;
+};
+
 const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
   ({
     selectedDayOfWeek,
+    selectableDaysOfWeek,
     isMidnightNotificationEnabled,
     isShowStartTime,
     isShowDuration,
@@ -97,7 +122,8 @@ const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
           <Stack width="$fluid" justify="center" gap="$size.x2_5">
             <Stack width="$fluid" flexDirection="row" justify="space-between" items="center">
               {DAY_OF_WEEK_ARRAY.map((day) => {
-                const isDayActive = day === selectedDayOfWeek;
+                const isDaySelectable = selectableDaysOfWeek.includes(day);
+                const isDayActive = isDaySelectable && day === selectedDayOfWeek;
                 const backgroundColor: ColorTokens = isDayActive ? '$colors.moonSoftWhite' : '$colors.midnightPurple';
                 const fontColor: ColorTokens = isDayActive ? '$colors.midnightPurple' : '$colors.moonSoftWhite';
                 const borderColor: ColorTokens = isDayActive ? '$colors.midnightPurple' : '$colors.cloudGray';
@@ -111,10 +137,13 @@ const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
                     bg={backgroundColor}
                     borderWidth={1}
                     borderColor={borderColor}
+                    opacity={isDaySelectable ? 1 : 0.35}
                     animation="quick"
                     style={{ borderRadius: 8 }}
-                    pressStyle={{ opacity: 0.6 }}
-                    onPress={() => onPressDay(day)}>
+                    pressStyle={isDaySelectable ? { opacity: 0.6 } : undefined}
+                    accessibilityRole="button"
+                    accessibilityState={{ disabled: !isDaySelectable, selected: isDayActive }}
+                    onPress={isDaySelectable ? () => onPressDay(day) : undefined}>
                     <Text fontSize="$7" fontWeight="$900" color={fontColor}>
                       {DAY_OF_WEEK_TEXT[day]}
                     </Text>
@@ -350,8 +379,33 @@ const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
   },
 );
 
+const YoasobiWeekCompleteBox = memo(() => (
+  <BlurBox>
+    <Stack width="$fluid" justify="center" items="center" gap="$size.x3" py="$size.x8">
+      <FontAwesomeIcon
+        size={36}
+        icon={faMoon}
+        color="#FED896"
+        style={{
+          shadowColor: '#FED896',
+          shadowOpacity: 1,
+          shadowRadius: 14,
+          shadowOffset: { width: 0, height: 0 },
+        }}
+      />
+      <Stack justify="center" items="center" gap="$size.x1_5">
+        <Text style={{ textAlign: 'center' }} fontSize="$8" fontWeight="$900" color="$colors.moonSoftWhite">
+          이번 주 YOASOBI를 모두 즐겼어요
+        </Text>
+        <Text style={{ textAlign: 'center' }} fontSize="$5" color="$colors.cloudGray">
+          다음 주에 새로운 새벽 산책을 정해보세요.
+        </Text>
+      </Stack>
+    </Stack>
+  </BlurBox>
+));
+
 const YoasobiResultBox = memo<IYoasobiResultBoxProps>(({ yoasobiDay, yoasobiDate, createdDate }) => {
-  const MS_PER_DAY = 1000 * 60 * 60 * 24;
   const yoasobiDateText = `${yoasobiDate.getHours()}:${yoasobiDate.getMinutes().toString().padStart(2, '0')}`;
 
   const now = new Date();
@@ -448,36 +502,41 @@ const YoasobiResultBox = memo<IYoasobiResultBoxProps>(({ yoasobiDay, yoasobiDate
 
 export const HomeScreen = memo(() => {
   const { userId, isReady } = useAuth();
-  const today = new Date();
+
+  const [currentDate, setCurrentDate] = useState<Date>(() => new Date());
+  const { weekStartDate } = useMemo(() => getWeekStartDateUtil({ currentDate }), [currentDate]);
+  const selectableDaysOfWeek = useMemo(() => getSelectableDaysOfWeek(currentDate), [currentDate]);
+  const initialSelectedDayOfWeek = selectableDaysOfWeek[0] ?? null;
+
   const [isMidnightNotificationEnabled, setIsMidnightNotificationEnabled] = useState<boolean>(false);
   const [existedYoasobi, setExistedYoasobi] = useState<IYoasobi | null>(null);
-  const [selectedDayOfWeek, setSelectedDayOfWeek] = useState<DayOfWeek>(DAY_OF_WEEK_ARRAY[today.getDay()]);
-  const [newYoasobiDate, setNewYoasobiDate] = useState<Date>(today);
+  const [selectedDayOfWeek, setSelectedDayOfWeek] = useState<DayOfWeek | null>(initialSelectedDayOfWeek);
+  const [newYoasobiDate, setNewYoasobiDate] = useState<Date>(() => {
+    if (!initialSelectedDayOfWeek) {
+      return new Date(currentDate);
+    }
+
+    return getYoasobiDateForDay({
+      weekStartDate,
+      dayOfWeek: initialSelectedDayOfWeek,
+      previousDate: currentDate,
+    });
+  });
   const [duration, setDuration] = useState<number>(MIN_YOASOBI_DURATION_MINUTES);
   const [isStartTimeSheetOpen, setIsStartTimeSheetOpen] = useState<boolean>(false);
   const [isDurationSheetOpen, setIsDurationSheetOpen] = useState<boolean>(false);
   const [getWeeklyYoasobiQuery] = useGetWeeklyYoasobiLazyQuery();
   const [createYoasobiMutation] = useCreateYoasobiMutation();
 
-  const { weekStartDate } = useMemo(() => {
-    const currentDate = new Date();
-    const { weekStartDate } = getWeekStartDateUtil({ currentDate });
-    return { weekStartDate };
-  }, []);
-
   const handlePressDay = useCallback(
     (day: DayOfWeek) => {
+      if (!selectableDaysOfWeek.includes(day)) {
+        return;
+      }
       setSelectedDayOfWeek(day);
-      const { dateByDayOfWeek } = getDateByDayOfWeekUtil({ weekStartDate, dayOfWeek: day });
-      setNewYoasobiDate((prev) => {
-        const prevStartTime = { hours: prev.getHours(), minutes: prev.getMinutes() };
-        const updatedDate = new Date(dateByDayOfWeek);
-        updatedDate.setHours(prevStartTime.hours);
-        updatedDate.setMinutes(prevStartTime.minutes);
-        return updatedDate;
-      });
+      setNewYoasobiDate((previousDate) => getYoasobiDateForDay({ weekStartDate, dayOfWeek: day, previousDate }));
     },
-    [weekStartDate],
+    [selectableDaysOfWeek, weekStartDate],
   );
 
   const handleCheckMidnightNotification = useCallback((checked: boolean) => {
@@ -540,11 +599,15 @@ export const HomeScreen = memo(() => {
   }, []);
 
   const handlePressRandomDay = useCallback(() => {
-    const randomIndex = Math.floor(Math.random() * DAY_OF_WEEK_ARRAY.length);
+    if (selectableDaysOfWeek.length === 0) {
+      return;
+    }
 
-    const selectedRandomDay = DAY_OF_WEEK_ARRAY[randomIndex];
-    setSelectedDayOfWeek(selectedRandomDay);
-  }, []);
+    const randomIndex = Math.floor(Math.random() * selectableDaysOfWeek.length);
+    const selectedRandomDay = selectableDaysOfWeek[randomIndex];
+
+    handlePressDay(selectedRandomDay);
+  }, [handlePressDay, selectableDaysOfWeek]);
 
   const fetchWeeklyYoasobi = useCallback(async () => {
     if (!userId) {
@@ -558,15 +621,12 @@ export const HomeScreen = memo(() => {
         },
       },
     });
-    const yoasobi = data?.getYoasobi.yoasobi;
-    if (!yoasobi) {
-      return;
-    }
-    setExistedYoasobi(yoasobi);
+    setExistedYoasobi(data?.getYoasobi.yoasobi ?? null);
   }, [getWeeklyYoasobiQuery, userId, weekStartDate]);
 
   const createNewYoasobi = useCallback(async () => {
-    if (!userId) {
+    const isSelectedDayValid = selectedDayOfWeek && selectableDaysOfWeek.includes(selectedDayOfWeek);
+    if (!userId || !isSelectedDayValid) {
       return;
     }
     const { data } = await createYoasobiMutation({
@@ -581,7 +641,7 @@ export const HomeScreen = memo(() => {
       },
     });
     return data;
-  }, [createYoasobiMutation, duration, newYoasobiDate, selectedDayOfWeek, userId]);
+  }, [createYoasobiMutation, duration, newYoasobiDate, selectableDaysOfWeek, selectedDayOfWeek, userId]);
 
   const handlePressCreateYoasobi = useCallback(async () => {
     await createNewYoasobi();
@@ -592,6 +652,34 @@ export const HomeScreen = memo(() => {
       fetchWeeklyYoasobi();
     }
   }, [userId, isReady, fetchWeeklyYoasobi]);
+
+  useEffect(() => {
+    if (selectedDayOfWeek && selectableDaysOfWeek.includes(selectedDayOfWeek)) {
+      return;
+    }
+
+    const nextSelectedDayOfWeek = selectableDaysOfWeek[0] ?? null;
+    setSelectedDayOfWeek(nextSelectedDayOfWeek);
+
+    if (nextSelectedDayOfWeek) {
+      setNewYoasobiDate((previousDate) =>
+        getYoasobiDateForDay({
+          weekStartDate,
+          dayOfWeek: nextSelectedDayOfWeek,
+          previousDate,
+        }),
+      );
+    }
+  }, [selectableDaysOfWeek, selectedDayOfWeek, weekStartDate]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const focusedDate = new Date();
+      setCurrentDate((previousDate) => (isSameLocalDate(previousDate, focusedDate) ? previousDate : focusedDate));
+    }, []),
+  );
+
+  const isCreationAvailable = selectedDayOfWeek !== null && selectableDaysOfWeek.length > 0;
 
   return (
     <DefaultLayout isBlur hasHeader>
@@ -611,10 +699,11 @@ export const HomeScreen = memo(() => {
               yoasobiDate={existedYoasobi.yoasobiDate}
               createdDate={existedYoasobi.createdAt}
             />
-          ) : (
+          ) : isCreationAvailable ? (
             <Stack flex={1} width="$fluid" gap="$size.x6">
               <YoasobiChoiceBox
                 selectedDayOfWeek={selectedDayOfWeek}
+                selectableDaysOfWeek={selectableDaysOfWeek}
                 isMidnightNotificationEnabled={isMidnightNotificationEnabled}
                 isShowStartTime={isStartTimeSheetOpen}
                 isShowDuration={isDurationSheetOpen}
@@ -651,6 +740,8 @@ export const HomeScreen = memo(() => {
                 </Text>
               </Button>
             </Stack>
+          ) : (
+            <YoasobiWeekCompleteBox />
           )}
         </Stack>
       </ScrollView>

--- a/apps/client/screens/home/home.screen.tsx
+++ b/apps/client/screens/home/home.screen.tsx
@@ -7,7 +7,7 @@ import {
   MS_PER_DAY,
 } from '@/constants';
 import { DayOfWeek, useCreateYoasobiMutation, useGetWeeklyYoasobiLazyQuery } from '@/libs';
-import { getDateByDayOfWeekUtil, getWeekStartDateUtil } from '@/utils';
+import { getDateByDayOfWeekUtil, getWeekStartDateUtil, parseDateTime } from '@/utils';
 import { faAlarmClock } from '@fortawesome/free-solid-svg-icons/faAlarmClock';
 import { faBell } from '@fortawesome/free-solid-svg-icons/faBell';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
@@ -140,10 +140,11 @@ const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
                     opacity={isDaySelectable ? 1 : 0.35}
                     animation="quick"
                     style={{ borderRadius: 8 }}
-                    pressStyle={isDaySelectable ? { opacity: 0.6 } : undefined}
-                    accessibilityRole="button"
-                    accessibilityState={{ disabled: !isDaySelectable, selected: isDayActive }}
-                    onPress={isDaySelectable ? () => onPressDay(day) : undefined}>
+                    aria-disabled={!isDaySelectable}
+                    aria-checked={isDayActive}
+                    disabled={!isDaySelectable}
+                    pressStyle={{ opacity: 0.6 }}
+                    onPress={() => onPressDay(day)}>
                     <Text fontSize="$7" fontWeight="$900" color={fontColor}>
                       {DAY_OF_WEEK_TEXT[day]}
                     </Text>
@@ -617,11 +618,21 @@ export const HomeScreen = memo(() => {
       variables: {
         input: {
           userId,
-          weekStartDate,
+          weekStartDate: weekStartDate.toISOString(),
         },
       },
     });
-    setExistedYoasobi(data?.getYoasobi.yoasobi ?? null);
+    const yoasobi = data?.getYoasobi.yoasobi;
+    setExistedYoasobi(
+      yoasobi
+        ? {
+            ...yoasobi,
+            yoasobiDate: parseDateTime(yoasobi.yoasobiDate),
+            alarmTime: parseDateTime(yoasobi.alarmTime),
+            createdAt: parseDateTime(yoasobi.createdAt),
+          }
+        : null,
+    );
   }, [getWeeklyYoasobiQuery, userId, weekStartDate]);
 
   const createNewYoasobi = useCallback(async () => {
@@ -634,13 +645,26 @@ export const HomeScreen = memo(() => {
         input: {
           userId,
           dayOfWeek: selectedDayOfWeek,
-          yoasobiDate: newYoasobiDate,
-          alarmTime: newYoasobiDate,
+          yoasobiDate: newYoasobiDate.toISOString(),
+          alarmTime: newYoasobiDate.toISOString(),
           duration,
         },
       },
+      fetchPolicy: 'network-only',
     });
-    return data;
+
+    const createdYoasobi = data?.createYoasobi.yoasobi;
+
+    setExistedYoasobi(
+      createdYoasobi
+        ? {
+            ...createdYoasobi,
+            yoasobiDate: parseDateTime(createdYoasobi.yoasobiDate),
+            alarmTime: parseDateTime(createdYoasobi.alarmTime),
+            createdAt: parseDateTime(createdYoasobi.createdAt),
+          }
+        : null,
+    );
   }, [createYoasobiMutation, duration, newYoasobiDate, selectableDaysOfWeek, selectedDayOfWeek, userId]);
 
   const handlePressCreateYoasobi = useCallback(async () => {

--- a/apps/client/screens/home/home.screen.tsx
+++ b/apps/client/screens/home/home.screen.tsx
@@ -382,7 +382,7 @@ const YoasobiChoiceBox = memo<IYoasobiChoiceBoxProps>(
 
 const YoasobiWeekCompleteBox = memo(() => (
   <BlurBox>
-    <Stack width="$fluid" justify="center" items="center" gap="$size.x3" py="$size.x8">
+    <Stack width="$fluid" justify="center" items="center" gap="$size.x6" py="$size.x4">
       <FontAwesomeIcon
         size={36}
         icon={faMoon}
@@ -394,9 +394,9 @@ const YoasobiWeekCompleteBox = memo(() => (
           shadowOffset: { width: 0, height: 0 },
         }}
       />
-      <Stack justify="center" items="center" gap="$size.x1_5">
+      <Stack justify="center" items="center" gap="$size.x2">
         <Text style={{ textAlign: 'center' }} fontSize="$8" fontWeight="$900" color="$colors.moonSoftWhite">
-          이번 주 YOASOBI를 모두 즐겼어요
+          이번 주 YOASOBI를 마쳤어요
         </Text>
         <Text style={{ textAlign: 'center' }} fontSize="$5" color="$colors.cloudGray">
           다음 주에 새로운 새벽 산책을 정해보세요.

--- a/apps/client/utils/index.ts
+++ b/apps/client/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './getWeekStartDate.util';
 export * from './getDateByDayOfWeek.util';
+export * from './parseDateTime.util';

--- a/apps/client/utils/parseDateTime.util.ts
+++ b/apps/client/utils/parseDateTime.util.ts
@@ -1,0 +1,9 @@
+type IParseDateTime = (dateTime: string) => Date;
+
+export const parseDateTime: IParseDateTime = (dateTime) => {
+  const parsedDate = new Date(dateTime);
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error(`Invalid DateTime: ${dateTime}`);
+  }
+  return parsedDate;
+};

--- a/apps/server/src/yoasobi/dto/deleteYoasobi.dto.ts
+++ b/apps/server/src/yoasobi/dto/deleteYoasobi.dto.ts
@@ -1,0 +1,15 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { IsUUID } from 'class-validator';
+
+@InputType()
+export class DeleteYoasobiInputDto {
+  @Field()
+  @IsUUID()
+  yoasobiId: string;
+}
+
+@ObjectType()
+export class DeleteYoasobiOutputDto {
+  @Field()
+  success: boolean;
+}

--- a/apps/server/src/yoasobi/dto/index.ts
+++ b/apps/server/src/yoasobi/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './createYoasobi.dto';
 export * from './getYoasobi.dto';
+export * from './deleteYoasobi.dto';

--- a/apps/server/src/yoasobi/resolvers/deleteYoasobi.resolver.ts
+++ b/apps/server/src/yoasobi/resolvers/deleteYoasobi.resolver.ts
@@ -1,0 +1,16 @@
+// implement deleteYoasobi resolver here. before implementing, check other resolvers's structure and follow the same pattern.
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { DeleteYoasobiInputDto, DeleteYoasobiOutputDto } from '../dto';
+import { DeleteYoasobiService } from '../services';
+
+@Resolver()
+export class DeleteYoasobiResolver {
+  constructor(private readonly deleteYoasobiService: DeleteYoasobiService) {}
+
+  @Mutation(() => DeleteYoasobiOutputDto)
+  async deleteYoasobi(
+    @Args('input') input: DeleteYoasobiInputDto,
+  ): Promise<DeleteYoasobiOutputDto> {
+    return await this.deleteYoasobiService.execute(input);
+  }
+}

--- a/apps/server/src/yoasobi/resolvers/index.ts
+++ b/apps/server/src/yoasobi/resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from './createYoasobi.resolver';
 export * from './getYoasobi.resolver';
+export * from './deleteYoasobi.resolver';

--- a/apps/server/src/yoasobi/services/deleteYoasobi.service.ts
+++ b/apps/server/src/yoasobi/services/deleteYoasobi.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma';
+import { DeleteYoasobiInputDto, DeleteYoasobiOutputDto } from '../dto';
+
+@Injectable()
+export class DeleteYoasobiService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async execute({
+    yoasobiId,
+  }: DeleteYoasobiInputDto): Promise<DeleteYoasobiOutputDto> {
+    await this.prismaService.yoasobi.delete({
+      where: { id: yoasobiId },
+    });
+    return { success: true };
+  }
+}

--- a/apps/server/src/yoasobi/services/index.ts
+++ b/apps/server/src/yoasobi/services/index.ts
@@ -1,2 +1,3 @@
 export * from './createYoasobi.service';
 export * from './getYoasobi.service';
+export * from './deleteYoasobi.service';

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "packages/shared"
   ],
   "scripts": {
+    "setup": "nvm use && yarn install",
     "dev:client": "yarn workspace @yoasobi/client start",
     "dev:server": "yarn workspace @yoasobi/server start:dev",
     "codegen": "yarn workspace @yoasobi/client codegen",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "packages/shared"
   ],
   "scripts": {
-    "setup": "nvm use && yarn install",
     "dev:client": "yarn workspace @yoasobi/client start",
     "dev:server": "yarn workspace @yoasobi/server start:dev",
     "codegen": "yarn workspace @yoasobi/client codegen",

--- a/packages/shared/graphql/schema.gql
+++ b/packages/shared/graphql/schema.gql
@@ -36,6 +36,10 @@ type GetYoasobiOutputDto {
   yoasobi: YoasobiEntity
 }
 
+type DeleteYoasobiOutputDto {
+  success: Boolean!
+}
+
 type CreateUserOutputDto {
   user: UserEntity!
 }
@@ -79,6 +83,7 @@ type Mutation {
   createUser(input: CreateUserInputDto!): CreateUserOutputDto!
   deleteUser(input: DeleteUserInputDto!): DeleteUserOutputDto!
   createYoasobi(input: CreateYoasobiInputDto!): CreateYoasobiOutputDto!
+  deleteYoasobi(input: DeleteYoasobiInputDto!): DeleteYoasobiOutputDto!
 }
 
 input CreateUserInputDto {
@@ -97,4 +102,8 @@ input CreateYoasobiInputDto {
   yoasobiDate: DateTime!
   alarmTime: DateTime!
   duration: Int!
+}
+
+input DeleteYoasobiInputDto {
+  yoasobiId: String!
 }


### PR DESCRIPTION
## 🔍 What is this PR?

주간 Yoasobi 생성 화면의 요일 제한과 완료 상태를 유지하면서, 리뷰에서 확인된 삭제 API 보안, 날짜 경계, 비동기 요청 경쟁 조건, 접근성, 에러 처리를 보완합니다.

Closes #5

## 주요 변경

- 남은 요일만 선택할 수 있으며 토요일에는 주간 완료 화면을 표시합니다.
- 화면 focus 및 로컬 자정에 현재 날짜를 갱신하고, 생성 직전 선택값을 다시 검증합니다.
- 사용자·기기 timezone·canonical 주 시작일·요청 순서를 기준으로 오래된 조회와 생성 응답을 무시합니다.
- 주간 조회와 생성은 같은 현재 기기 IANA timezone을 사용하며, 서버가 현재 시각으로 canonical Sunday UTC date-only key를 도출합니다.
- 생성 입력에서 weekStartDate를 제거하고 요청 날짜와 요일이 같은 로컬 주의 미래 요일인지 서버에서 검증합니다.
- 조회 상태를 loading / ready / error로 분리하고 재시도 UI를 제공합니다.
- 요일 선택을 controlled RadioGroup으로 바꾸고 랜덤 선택에 button 의미를 부여합니다.
- Supabase Bearer token을 검증하고 JWT sub 소유자에 한해 Yoasobi 삭제를 허용합니다.
- Supabase auth callback 잠금 재진입과 사용자 교체 중 stale profile 반영을 방지합니다.
- production GraphQL endpoint는 HTTPS만 허용하고 개발 loopback만 HTTP를 허용합니다.
- 전역 ValidationPipe를 활성화하고 삭제 대상이 없거나 타인 소유이면 동일한 NotFound를 반환합니다.
- 로그아웃 또는 사용자 교체 시 Apollo cache를 비웁니다.
- 나머지 사용자 범위 API의 JWT sub 전환은 후속 보안 이슈 #7로 추적합니다.

## 📸 스크린샷

- [ ] 변경 전/후 실제 기기 스크린샷 추가

## ✅ 검증 결과

- [x] yarn codegen
- [x] client Jest: 5 suites, 20 tests
- [x] handwritten client source/test ESLint: 0 errors, 0 warnings
- [x] client TypeScript: tsc --noEmit
- [x] server Jest: 8 suites, 26 tests
- [x] server build: nest build
- [x] git diff --check
- [x] GitGuardian Security Checks
- [ ] VoiceOver 또는 TalkBack 실제 기기 확인

> yarn workspace @yoasobi/client lint는 Expo가 현재 저장소에 없는 apps/client/app 경로를 고정 대상으로 전달해 실패합니다. 같은 ESLint 구성으로 변경한 클라이언트 소스와 테스트를 직접 검사했습니다.